### PR TITLE
Updates to the Proxy Handling 

### DIFF
--- a/tasks/detect-task/detect-task.ps1
+++ b/tasks/detect-task/detect-task.ps1
@@ -99,7 +99,16 @@ foreach ($AdditionalArgument in $ParsedArguments){
 Write-Host "Downloading detect powershell library"
 $DetectDownloadSuccess = $false;
 try {
+        if ($UseProxy -eq $true){
+            $ProxyCreds = New-Object System.Management.Automation.PSCredential(
+                ${Env:blackduck.hub.proxy.username},
+                (ConvertTo-SecureString ${Env:blackduck.hub.proxy.password} -AsPlainText -Force)
+            );
+               Invoke-RestMethod https://blackducksoftware.github.io/hub-detect/hub-detect.ps1?$(Get-Random) -Proxy ${Env:blackduck.hub.proxy.host}":"${Env:blackduck.hub.proxy.port} -ProxyCredential $ProxyCreds | Invoke-Expression;
+        } else {
 	Invoke-RestMethod https://blackducksoftware.github.io/hub-detect/hub-detect.ps1?$(Get-Random) | Invoke-Expression;
+	{
+
 	$DetectDownloadSuccess = $true;
 } catch  [Exception] {
     Write-Host ("Failed to download the latest detect powershell library from the web. Using the embedded version.")

--- a/tasks/detect-task/detect-task.ps1
+++ b/tasks/detect-task/detect-task.ps1
@@ -107,8 +107,7 @@ try {
                Invoke-RestMethod https://blackducksoftware.github.io/hub-detect/hub-detect.ps1?$(Get-Random) -Proxy ${Env:blackduck.hub.proxy.host}":"${Env:blackduck.hub.proxy.port} -ProxyCredential $ProxyCreds | Invoke-Expression;
         } else {
 	Invoke-RestMethod https://blackducksoftware.github.io/hub-detect/hub-detect.ps1?$(Get-Random) | Invoke-Expression;
-	{
-
+	}
 	$DetectDownloadSuccess = $true;
 } catch  [Exception] {
     Write-Host ("Failed to download the latest detect powershell library from the web. Using the embedded version.")

--- a/tasks/detect-task/lib/detect.ps1
+++ b/tasks/detect-task/lib/detect.ps1
@@ -104,8 +104,7 @@ function Get-ProxyInfo () {
             Write-Host "Skipping proxy, no host found."
         }else{
             Write-Host "Found proxy host."
-            $ProxyUrlBuilder = New-Object System.UriBuilder
-            $ProxyUrlBuilder.Host = $ProxyHost
+            $ProxyUrlBuilder = [UriBuilder]($ProxyHost)
 
             $ProxyPort = ${Env:blackduck.hub.proxy.port};
 


### PR DESCRIPTION
detect-task.ps1:
When hub is running on a machine that does not have direct outside internet connection it won't be able to reach the github repository to download the newest version of detect.ps1.  This change uses the Hub Proxy settings with the Invoke-RestMethod to use the proxy to get outside access. If you are not using the proxy it does nothing different. 

detect.ps1

Previously the Proxy Url builder would end up returning an empty string with the way this was parsing. Now we are using the Proxy's string to create the new URIBuilder object and then assigning the port.  Now when we call ProxyUrlBuilder.Uri we actually get a correctly configured Uri verses an empty value which ends up throwing an exception.


Test Code:  
`
           Write-Host "ProxyUrlBuild Host: " $ProxyUrlBuilder.Host
            Write-Host "ProxyUrlBuild Port: " $ProxyUrlBuilder.Port
            Write-Host "ProxyUrlBuild Uri: "  $ProxyUrlBuilder.Uri

            $ProxyInfoProperties.Uri = $ProxyUrlBuilder.Uri
`

Output Before:

>
Checking for proxy.
Found proxy host.
Found proxy port.
ProxyUrlBuild Host:  [http://*****.domainName.com]
ProxyUrlBuild Port:  1234
ProxyUrlBuild Uri:  
Found proxy credentials.
Successfully setup proxy.
Getting detect.
Finding latest detect version.
System.Management.Automation.ValidationMetadataException
The cmdlet cannot run because the following parameter is missing: Proxy. Provide a valid proxy URI for the Proxy parameter when using the ProxyCredential or UseDefaultProxyCredentials parameters, then retry.


Output After:

> 
Checking for proxy.
Found proxy host.
Found proxy port.
ProxyUrlBuild Host:  http://*****.domainName.com
ProxyUrlBuild Port:  1234
ProxyUrlBuild Uri:  http://*****.domainName.com:1234/
Found proxy credentials.
Successfully setup proxy.
Getting detect.
Finding latest detect version.
Resolved version 3.1.0
Using detect version 3.1.0