### PR TITLE
Use proxy for github request and allow scheme in proxy host

### DIFF
--- a/tasks/detect-task/lib/detect.ps1
+++ b/tasks/detect-task/lib/detect.ps1
@@ -44,7 +44,7 @@ $EnvHomeTempFolder = "$HOME\tmp"
 # heap size, you would set DETECT_JAVA_OPTS=-Xmx6G.
 #$DetectJavaOpts = Get-EnvironmentVariable -Key "DETECT_JAVA_OPTS" -DefaultValue "";
 
-$Version = "0.6.4"
+$Version = "0.6.5"
 
 $DetectReleaseBaseUrl = "https://test-repo.blackducksoftware.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/hub-detect"
 $DetectSnapshotBaseUrl = "https://test-repo.blackducksoftware.com/artifactory/bds-integrations-snapshot/com/blackducksoftware/integration/hub-detect"
@@ -57,7 +57,14 @@ function Detect {
     Write-Host "Detect Powershell Script $Version"
     
     if ($EnvDetectSkipJavaTest -ne "1"){
-    	Test-JavaExists
+    	if (Test-JavaNotAvailable){ #If java is not available, we abort early.
+			$JavaExitCode = 127 #Command not found http://tldp.org/LDP/abs/html/exitcodes.html 
+    		if ($EnvDetectExitCodePassthru -eq "1"){
+		        return $JavaExitCode
+		    }else{
+		    	exit $JavaExitCode
+		    }
+    	}
     }else{
    		Write-Host "Skipping java test."
     }
@@ -97,15 +104,14 @@ function Get-ProxyInfo () {
         $ProxyHost = ${Env:blackduck.hub.proxy.host};
         
         if ([string]::IsNullOrEmpty($ProxyHost)){
-			$ProxyHost = ${BLACKDUCK_HUB_PROXY_HOST};
+			$ProxyHost = ${Env:BLACKDUCK_HUB_PROXY_HOST};
 		}
         
         if ([string]::IsNullOrEmpty($ProxyHost)){
             Write-Host "Skipping proxy, no host found."
         }else{
             Write-Host "Found proxy host."
-            $ProxyUrlBuilder = New-Object System.UriBuilder
-            $ProxyUrlBuilder.Host = $ProxyHost
+            $ProxyUrlBuilder = New-Object System.UriBuilder -ArgumentList $ProxyHost
 
             $ProxyPort = ${Env:blackduck.hub.proxy.port};
 
@@ -303,7 +309,7 @@ function Set-ToEscaped ($ArgArray){
     }
 }
 
-function Test-JavaExists() {
+function Test-JavaNotAvailable() {
 	Write-Host "Checking if Java is installed by asking for version."
 	try {
 		$ProcessStartInfo = New-object System.Diagnostics.ProcessStartInfo 
@@ -322,8 +328,9 @@ function Test-JavaExists() {
 		Write-Host "Java Standard Output: $StdOutput"
 		Write-Host "Java Error Output: $StdError"
 		Write-Host "Successfully able to start java and get version."
+		return $FALSE;
 	}catch { 
 		Write-Host "An error occurred checking the Java version. Please ensure Java is installed."
-		exit 127 #Command not found http://tldp.org/LDP/abs/html/exitcodes.html
+		return $TRUE;
 	}
 }


### PR DESCRIPTION
Fixes two issues:
1. Use a proxy if available to download the detect script from github. This code was moved from the detect powershell script up to the tfs script. Unfortunately we will now need to keep them in sync.
2. When a scheme is provided in the host, the UriBuilder was failing to parse it. Now we treat host as a uri and let the builder's constructor parse it. This change also happened on the detect repository. 