### PR TITLE
Added settings for "Project Name" and "Project Version"

### DIFF
--- a/tasks/synopsys-detect-task/detect-task.ps1
+++ b/tasks/synopsys-detect-task/detect-task.ps1
@@ -109,8 +109,18 @@ if ($ConfiguredProduct -eq "PS" -OR $ConfiguredProduct -eq "ALL"){
 }
 
 #Get Other Input
-
 $DetectAdditionalArguments = Get-VstsInput -Name DetectArguments -Default ""
+
+$DetectProjectName = Get-VstsInput -Name DetectProjectName -Default ""
+if (-Not [string]::IsNullOrWhiteSpace($DetectProjectName)){
+    $DetectAdditionalArguments = $DetectAdditionalArguments + " --detect.project.name=" + $DetectProjectName # Add the name of the project as Argument to be then parsed.
+}
+
+$DetectProjectVersion = Get-VstsInput -Name DetectProjectVersion -Default ""
+if (-Not [string]::IsNullOrWhiteSpace($DetectProjectVersion)){
+    $DetectAdditionalArguments = $DetectAdditionalArguments + " --detect.project.version.name=" + $DetectProjectVersion # Add the version of the project as Argument to be then parsed.
+}
+
 $AddTaskSummary = Get-VstsInput -Name AddTaskSummary -Default $true
 
 $DetectFolder = Get-VstsInput -Name DetectFolder -Default ""

--- a/tasks/synopsys-detect-task/task.json
+++ b/tasks/synopsys-detect-task/task.json
@@ -67,6 +67,22 @@
       "helpMarkDown": "Version of the detect binary to use. Default: Latest."
     },
     {
+      "name": "DetectProjectName",
+      "type": "string",
+      "label": "Detect Project Name",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "The Project name. If empty, it defaults to the name of the folder where the tool is running."
+    },
+    {
+      "name": "DetectProjectVersion",
+      "type": "string",
+      "label": "Detect Project Version",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The Version of the project. If empty, it defaults to 'Default Detect Version'"
+    },
+    {
       "name": "DetectArguments",
       "type": "multiLine",
       "label": "Detect Arguments",

--- a/tasks/synopsys-detect-task/task.json
+++ b/tasks/synopsys-detect-task/task.json
@@ -72,14 +72,14 @@
       "label": "Detect Project Name",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "The Project name. If empty, it defaults to the name of the folder where the tool is running."
+      "helpMarkDown": "The Project name. If empty, it defaults to the name of the folder where the tool is running"
     },
     {
       "name": "DetectProjectVersion",
       "type": "string",
       "label": "Detect Project Version",
       "defaultValue": "",
-      "required": true,
+      "required": false,
       "helpMarkDown": "The Version of the project. If empty, it defaults to 'Default Detect Version'"
     },
     {


### PR DESCRIPTION
Added the setting for "Project Name" and "Project Version" so users don't have to insert that manually into the _Arguments_ box and there is no need for them to look into the documentation to find out how to do so

This makes the extension much more user friendly.

Fixes #13 